### PR TITLE
add inductive learning

### DIFF
--- a/sampler.py
+++ b/sampler.py
@@ -15,6 +15,13 @@ class NegLinkSampler:
     def sample(self, n):
         return np.random.randint(self.num_nodes, size=n)
 
+class NegLinkInductiveSampler:
+    def __init__(self, nodes):
+        self.nodes = list(nodes)
+
+    def sample(self, n):
+        return np.random.choice(self.nodes, size=n)
+    
 if __name__ == '__main__':
     parser=argparse.ArgumentParser()
     parser.add_argument('--data', type=str, help='dataset name')


### PR DESCRIPTION
The inductive learning setting follows the implementation in [TGAT](https://github.com/StatsDLMathsRecomSys/Inductive-representation-learning-on-temporal-graphs). I achieve this by generating a new `df` and introduce a new negative sampler.

To run inductive learning, simply add `--use_inductive` at the end of the commands. For example `python train.py --data REDDIT  --config config/TGN.yml --model_name reddit_tgn --seed --use_inductive`

I tested the results locally, it seems to work well.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
