### PR TITLE
fix a bug in train_dist for TGAT

### DIFF
--- a/train_dist.py
+++ b/train_dist.py
@@ -144,12 +144,12 @@ class DataPipelineThread(threading.Thread):
             prepare_input(mfgs, node_feats, edge_feats, pinned=True, nfeat_buffs=pinned_nfeat_buffs, efeat_buffs=pinned_efeat_buffs, nids=nids, eids=eids)
             if mailbox is not None:
                 mailbox.prep_input_mails(mfgs[0], use_pinned_buffers=True)
-                self.mfgs = mfgs
-                self.root = self.my_root[0]
-                self.ts = self.my_ts[0]
-                self.eid = self.my_eid[0]
                 if memory_param['deliver_to'] == 'neighbors':
                     self.block = self.my_block[0]
+            self.mfgs = mfgs
+            self.root = self.my_root[0]
+            self.ts = self.my_ts[0]
+            self.eid = self.my_eid[0]
             # print(args.local_rank, 'finished')
 
     def get_stream(self):


### PR DESCRIPTION
Issue #: None

Description of changes:

The script `train_dist.py` would throw out an error stating the input MFGs are None for non-memory-based TGNNs. This is because the DataPipelineThread class to prepare minibatch data in different CUDA streams does not store the result MFGs, due to an embarrassing bug of the `if` clause at `train_dist.py:145`. This PR fixes this bug. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
